### PR TITLE
fix: properly handle if `shiftwidth = 0`

### DIFF
--- a/lua/typescript-tools/protocol/text_document/did_open.lua
+++ b/lua/typescript-tools/protocol/text_document/did_open.lua
@@ -24,7 +24,10 @@ local function configure(params)
 
   local bo = vim.bo[vim.uri_to_bufnr(text_document.uri)]
   local tab_size = bo.tabstop or 2
-  local indent_size = bo.shiftwidth or tab_size
+  local indent_size = bo.shiftwidth
+  if indent_size == 0 or not indent_size then
+    indent_size = tab_size
+  end
   local convert_tabs_to_spaces = bo.expandtab or true
   local new_line_character = get_eol_chars(bo)
 


### PR DESCRIPTION
According to `:h 'shiftwidth'` if the value is 0 then `tabstop` is used. Currently it will just use 0 as the indent size, this fixes this.